### PR TITLE
Fix parsing when response is not valid JSON.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+marathon-api

--- a/fixtures/vcr/Marathon/_ping/handles_incorrect_content_type.yml
+++ b/fixtures/vcr/Marathon/_ping/handles_incorrect_content_type.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/ping
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - ub0r/Marathon-API 1.3.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 02 Mar 2016 11:32:08 GMT
+      - Wed, 02 Mar 2016 11:32:08 GMT
+      Server:
+      - Jetty(9.3.z-SNAPSHOT)
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; qs=2
+      Content-Length:
+      - '5'
+    body:
+      encoding: UTF-8
+      string: |
+        pong
+    http_version:
+  recorded_at: Wed, 02 Mar 2016 11:32:28 GMT
+recorded_with: VCR 2.9.3

--- a/lib/marathon.rb
+++ b/lib/marathon.rb
@@ -44,7 +44,7 @@ module Marathon
       begin
         connection.get('/ping')
       rescue Marathon::Error::UnexpectedResponseError => err
-        return err.response.body if err.response.code == 200 
+        return err.response.body if err.response.code == 200
         raise err
       end
     end

--- a/lib/marathon.rb
+++ b/lib/marathon.rb
@@ -41,7 +41,12 @@ module Marathon
     end
 
     def ping
-      connection.get('/ping')
+      begin
+        connection.get('/ping')
+      rescue Marathon::Error::UnexpectedResponseError => err
+        return err.response.body if err.response.code == 200 
+        raise err
+      end
     end
 
     # Get information about the marathon server

--- a/lib/marathon/connection.rb
+++ b/lib/marathon/connection.rb
@@ -88,7 +88,11 @@ class Marathon::Connection
   # ++response++: response from HTTParty call.
   def parse_response(response)
     if response.success?
-      response.parsed_response
+      begin
+        response.parsed_response
+      rescue => err
+        raise Marathon::Error.from_response(response)
+      end
     else
       raise Marathon::Error.from_response(response)
     end

--- a/lib/marathon/error.rb
+++ b/lib/marathon/error.rb
@@ -19,6 +19,7 @@ module Marathon::Error
 
   # Raised when there is an unexpected response code / body.
   class UnexpectedResponseError < MarathonError;
+    attr_accessor :response
   end
 
   # Raised when a request times out.
@@ -36,7 +37,9 @@ module Marathon::Error
   # Raise error specific to http response.
   # ++response++: HTTParty response object.
   def from_response(response)
-    error_class(response).new(error_message(response))
+    error_class(response).new(error_message(response)).tap do |err|
+      err.response = response if err.is_a?(UnexpectedResponseError)
+    end
   end
 
   private
@@ -69,6 +72,8 @@ module Marathon::Error
     else
       body
     end
+  rescue JSON::ParserError
+    body
   end
 
   module_function :error_class, :error_message, :from_response

--- a/spec/marathon/marathon_spec.rb
+++ b/spec/marathon/marathon_spec.rb
@@ -91,5 +91,9 @@ describe Marathon do
     it 'returns pong' do
       ping.should == "pong\n"
     end
+
+    it 'handles incorrect content type' do
+      ping.should =~ /pong/
+    end
   end
 end


### PR DESCRIPTION
We found that the response for `/ping` has changed between DC/OS 1.8 and 1.9, although the [documentation](https://mesosphere.github.io/marathon/docs/rest-api.html#user-content-get-ping) has not changed. I will also be logging an issue to DC/OS / Mesos but thought it might be useful to handle a few of these cases in this library.

The documentation states that it will return `Content-Type: text/plain;charset=ISO-8859-1` but it now returns `application/json; qs=2`. HTTParty is trying to [`JSON.parse`](https://github.com/jnunemaker/httparty/blob/v0.15.4/lib/httparty/parser.rb#L122-L124) for that content-type, and [`Marathon::Error`](https://github.com/otto-de/marathon-api/blob/2.1.0/lib/marathon/error.rb#L62) is trying to parse the body when serializing an error, which causes a parsing error and context of the raw response to be lost.  

I was able to handle this case with the attached modifications, and was looking for thoughts. 